### PR TITLE
Added support for controlling Object3Ds

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ There is also bunch more examples you can check out if you are more of a 'stare 
 
 * [Drag] - A basic Drag and Drop example
 * [Highlight] - The Most Basic example of highlighting different balls
+* [HighlightGroup] - Highlight groups of balls
 * [Displace] - Balls move away from your mouse when hit
 * [Noises] - make noises when you hit the objects
 
@@ -59,6 +60,7 @@ The object controls are used by adding meshes to them. All of the logic of what 
     var mat = new THREE.MeshNormalMaterial();
     var geo = new THREE.IcosahedronGeometry( 10 , 1 );
     var mesh = new THREE.Mesh( geo , mat );
+    objectControls.add( mesh );
     
     
     // This is what will be called when
@@ -97,6 +99,8 @@ The object controls are used by adding meshes to them. All of the logic of what 
     
 ```
 
+In addition to controling a mesh as shown above, you can also control an Object3D with child meshes. Then events are triggered on the Object3D whenever any of its child meshes are intersected. To enable, set recursive:true in the params passed to the ObjectControls constructor, as shown in the [HighlightGroup] example.
+
 As usual, although the code is stable, this is still a work in progress, so if you see any problems, please please please let me know! Also, if there is something you want to see implemented, have any other suggestions, or use the code for anything I'd love to see how you used it, so hit me up on [Twitter]
 
 
@@ -108,6 +112,7 @@ As usual, although the code is stable, this is still a work in progress, so if y
 
 [Drag]: http://cabbi.bo/ObjectControls/examples/drag.html
 [Highlight]: http://cabbi.bo/ObjectControls/examples/highlight.html
+[HighlightGroup]: http://cabbi.bo/ObjectControls/examples/highlightGroup.html
 [Displace]: http://cabbi.bo/ObjectControls/examples/displace.html
 [Noises]: http://cabbi.bo/ObjectControls/examples/noises.html
 

--- a/examples/highlightGroup.html
+++ b/examples/highlightGroup.html
@@ -1,0 +1,155 @@
+<html>
+<body style="margin:0px">
+  <script src="../lib/three.min.js"></script>
+  <script src="../ObjectControls.js"></script>
+  <script>
+
+
+    var scene, camera, renderer;
+
+    var objectControls;
+    var objects = [];
+
+    init();
+    animate();
+
+    function init(){
+
+
+      /*
+
+         Default threejs stuff!
+
+      */
+      scene = new THREE.Scene();
+
+      var ar = window.innerWidth / window.innerHeight;
+
+      camera = new THREE.PerspectiveCamera( 75, ar , 1, 1000 );
+      camera.position.z = 100;
+
+      renderer = new THREE.WebGLRenderer();
+      renderer.setSize( window.innerWidth, window.innerHeight );
+
+      document.body.appendChild( renderer.domElement );
+
+
+      /*
+
+         Object Control stuff!!!!
+
+      */ 
+
+      var params = { recursive: true };
+      objectControls = new ObjectControls( camera, params );
+
+      var hoverMaterial     = new THREE.MeshNormalMaterial();
+      var neutralMaterial   = new THREE.MeshBasicMaterial({color:0xffcccc, wireframe: true});
+      var selectedMaterial  = new THREE.MeshBasicMaterial({color:0x55ff88});
+
+      var radius = 10;
+      var geo = new THREE.SphereGeometry( radius, 20, 20 );
+
+      for( var i = 0; i < 15; i++ ){
+
+        var group = new THREE.Object3D();
+        for ( var j = 0; j < 3; j++) {
+
+          var mesh = new THREE.Mesh( geo , neutralMaterial );
+          mesh.position.x += j * radius * 2;
+          group.add(mesh);
+
+        }
+
+        group.hoverMaterial    = hoverMaterial;
+        group.neutralMaterial  = neutralMaterial;
+        group.selectedMaterial = selectedMaterial;
+
+        group.selected = false;
+
+        group.hoverOver = function(){
+
+          for ( var i = 0; i < group.children.length; i++ ) {
+
+            this.children[i].material = this.hoverMaterial;
+            this.children[i].materialNeedsUpdate = true;
+
+          }
+
+        }.bind( group );
+
+
+        group.hoverOut = function(){
+
+          for ( var i = 0; i < group.children.length; i++ ) {
+
+            if( this.selected ){
+              this.children[i].material = this.selectedMaterial;
+              this.children[i].materialNeedsUpdate = true;
+            }else{
+              this.children[i].material = this.neutralMaterial;
+              this.children[i].materialNeedsUpdate = true;
+            }
+
+          }
+
+        }.bind( group );
+
+        group.select = function(){
+
+          this.selected = true;
+          for ( var i = 0; i < group.children.length; i++ ) {
+
+            this.children[i].material = this.selectedMaterial;
+            this.children[i].materialNeedsUpdate = true;
+
+          }
+
+        }
+
+        group.deselect = function(){
+
+          this.selected = false;
+          for ( var i = 0; i < group.children.length; i++ ) {
+
+            this.children[i].material = this.neutralMaterial;
+            this.children[i].materialNeedsUpdate = true;
+
+          }
+
+        }
+
+
+        group.position.x = (Math.random() -.5 ) * 200;
+        group.position.y = (Math.random() -.5 ) * 200;
+        group.position.z = (Math.random() -.5 ) * 100;
+        group.rotation.z = (Math.random() -.5 ) * Math.PI * 2;
+        scene.add( group );
+
+        objectControls.add( group );
+
+      }
+
+    }
+
+    function animate(){
+
+      requestAnimationFrame( animate );
+
+
+      
+      objectControls.update();
+
+      renderer.render( scene , camera );
+  
+
+
+    }
+
+  </script>
+
+
+
+
+</body>
+<html>

--- a/index.html
+++ b/index.html
@@ -65,6 +65,7 @@
   <ul>
   <li><a href="http://cabbi.bo/ObjectControls/examples/drag.html">Drag</a> - A basic Drag and Drop example</li>
   <li><a href="http://cabbi.bo/ObjectControls/examples/highlight.html">Highlight</a> - The Most Basic example of highlighting different balls</li>
+  <li><a href="http://cabbi.bo/ObjectControls/examples/highlightGroup.html">HighlightGroup</a> - Highlight groups of balls</li>
   <li><a href="http://cabbi.bo/ObjectControls/examples/displace.html">Displace</a> - Balls move away from your mouse when hit</li>
   <li><a href="http://cabbi.bo/ObjectControls/examples/noises.html">Noises</a> - make noises when you hit the objects</li>
   </ul>
@@ -121,6 +122,7 @@
 
       }
   </code></pre>
+  <p>In addition to controling a mesh as shown above, you can also control an Object3D with child meshes. Then events are triggered on the Object3D whenever any of its child meshes are intersected. To enable, set recursive:true in the params passed to the ObjectControls constructor, as shown in the <a href="http://cabbi.bo/ObjectControls/examples/highlightGroup.html">HighlightGroup</a> example.</p>
   <p>As usual, although the code is stable, this is still a work in progress, so if you see any problems, please please please let me know! Also, if there is something you want to see implemented, have any other suggestions, or use the code for anything I&#39;d love to see how you used it, so hit me up on <a href="http://twitter.com/cabbibo">Twitter</a></p>
 </div>
 


### PR DESCRIPTION
Can now control an Object3D, and events are triggered on it whenever any of its child meshes are intersected. To enable, set recursive:true in the params passed to the ObjectControls.  Added highlightGroup.html example and updated README.md and index.html to mention this new feature.

Addresses issue #1 but note this is not traditional event bubbling, since events are only triggered on those objects added with objectControls.add() and not on the child objects, although the child objects are checked for intersections.
